### PR TITLE
feat: PRODUCT_LADDER 방 타입 구현

### DIFF
--- a/app/domain/game/models.py
+++ b/app/domain/game/models.py
@@ -23,9 +23,21 @@ class GameResult(Base):
     game_id = Column(BigInteger, ForeignKey("games.id"), nullable=False, index=True)
     product_id = Column(BigInteger, ForeignKey("products.id"), nullable=False, index=True)
     recipient_user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False, index=True)
-    payer_user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False, index=True)
+    payer_user_id = Column(BigInteger, ForeignKey("users.id"), index=True)  # WISHLIST_GIFT용 (단일 결제자)
     payment_status = Column(String(20), nullable=False, default="PENDING")  # PENDING | PAID | FAILED | CANCELED
     fake_payment_id = Column(String(64))
     paid_at = Column(DateTime)
     message_sent_at = Column(DateTime)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class GamePayer(Base):
+    """PRODUCT_LADDER 방용 - 다중 결제자"""
+    __tablename__ = "game_payers"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    game_result_id = Column(BigInteger, ForeignKey("game_results.id"), nullable=False, index=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False, index=True)
+    payment_status = Column(String(20), nullable=False, default="PENDING")  # PENDING | PAID | FAILED
+    paid_at = Column(DateTime)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/app/domain/room/repository.py
+++ b/app/domain/room/repository.py
@@ -56,6 +56,20 @@ class RoomRepository:
         )
 
     @staticmethod
+    def list_by_product(db: Session, product_id: int) -> List[Room]:
+        """특정 상품의 OPEN 상태 PRODUCT_LADDER 방 목록 조회"""
+        return (
+            db.query(Room)
+            .filter(
+                Room.product_id == product_id,
+                Room.status == "OPEN",
+                Room.room_type == "PRODUCT_LADDER",
+            )
+            .order_by(Room.created_at.desc())
+            .all()
+        )
+
+    @staticmethod
     def create(
         db: Session,
         room_type: str,
@@ -63,7 +77,7 @@ class RoomRepository:
         max_participants: int,
         owner_user_id: int,
         product_id: int,
-        gift_owner_user_id: int,
+        gift_owner_user_id: Optional[int],
     ) -> Room:
         join_code = secrets.token_urlsafe(16)
         room = Room(

--- a/app/domain/room/schemas.py
+++ b/app/domain/room/schemas.py
@@ -5,7 +5,14 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class RoomCreate(BaseModel):
+    """WISHLIST_GIFT 방 생성 요청"""
     wishlist_item_id: int = Field(..., gt=0, description="위시리스트 아이템 ID")
+    title: Optional[str] = Field(None, max_length=120, description="방 제목")
+    max_participants: int = Field(..., ge=2, le=10, description="최대 참여자 수")
+
+
+class ProductRoomCreate(BaseModel):
+    """PRODUCT_LADDER 방 생성 요청"""
     title: Optional[str] = Field(None, max_length=120, description="방 제목")
     max_participants: int = Field(..., ge=2, le=10, description="최대 참여자 수")
 
@@ -72,10 +79,11 @@ class ReadyRequest(BaseModel):
 
 class GameResultInfo(BaseModel):
     game_id: int
-    payer_user_id: Optional[int] = None  # 참여자만 볼 수 있음
+    payer_user_id: Optional[int] = None  # WISHLIST_GIFT: 참여자만 볼 수 있음
     recipient_user_id: int
     product_id: int
     participant_user_ids: List[int] = []  # 방장은 참여자 목록만 볼 수 있음
+    payer_user_ids: List[int] = []  # PRODUCT_LADDER: 결제자 목록 (당첨자 제외)
 
 
 class ReadyResponse(BaseModel):

--- a/app/domain/room/service.py
+++ b/app/domain/room/service.py
@@ -5,11 +5,11 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import BadRequestException, ForbiddenException, NotFoundException
 from app.domain.friend.repository import FriendRepository
-from app.domain.game.models import Game, GameResult
-from app.domain.game.repository import GameRepository, GameResultRepository
+from app.domain.game.models import Game, GameResult, GamePayer
+from app.domain.game.repository import GameRepository, GameResultRepository, GamePayerRepository
 from app.domain.room.models import Room
 from app.domain.room.repository import RoomRepository, RoomParticipantRepository
-from app.domain.room.schemas import RoomCreate, RoomDetailResponse, RoomResponse, ParticipantResponse, ReadyRequest, GameResultInfo
+from app.domain.room.schemas import RoomCreate, ProductRoomCreate, RoomDetailResponse, RoomResponse, ParticipantResponse, ReadyRequest, GameResultInfo
 from app.domain.wishlist.models import WishlistItem
 
 
@@ -21,12 +21,14 @@ class RoomService:
         friend_repository: FriendRepository | None = None,
         game_repository: GameRepository | None = None,
         game_result_repository: GameResultRepository | None = None,
+        game_payer_repository: GamePayerRepository | None = None,
     ) -> None:
         self.room_repository = room_repository or RoomRepository()
         self.participant_repository = participant_repository or RoomParticipantRepository()
         self.friend_repository = friend_repository or FriendRepository()
         self.game_repository = game_repository or GameRepository()
         self.game_result_repository = game_result_repository or GameResultRepository()
+        self.game_payer_repository = game_payer_repository or GamePayerRepository()
 
     def create_room(self, db: Session, user_id: int, payload: RoomCreate) -> RoomResponse:
         """위시리스트 아이템으로 방 생성"""
@@ -54,6 +56,30 @@ class RoomService:
         response.current_participant_count = 0
         return response
 
+    def create_product_room(self, db: Session, user_id: int, product_id: int, payload: ProductRoomCreate) -> RoomResponse:
+        """상품 기반 방 생성 (PRODUCT_LADDER)"""
+        from app.domain.product.models import Product
+
+        # 상품 존재 확인
+        product = db.query(Product).filter(Product.id == product_id).first()
+        if not product:
+            raise NotFoundException(message="Product not found")
+
+        # 방 생성
+        room = self.room_repository.create(
+            db,
+            room_type="PRODUCT_LADDER",
+            title=payload.title,
+            max_participants=payload.max_participants,
+            owner_user_id=user_id,
+            product_id=product_id,
+            gift_owner_user_id=None,  # PRODUCT_LADDER는 선물받는 대상이 미정
+        )
+
+        response = RoomResponse.model_validate(room)
+        response.current_participant_count = 0
+        return response
+
     def get_room_detail(self, db: Session, user_id: int, room_id: int) -> RoomDetailResponse:
         """방 상세 조회 (입장 화면)"""
         room = self.room_repository.get_by_id(db, room_id)
@@ -63,14 +89,15 @@ class RoomService:
         if room.status == "DELETED":
             raise NotFoundException(message="Room not found")
 
-        # 방장이거나 친구인지 확인
-        is_owner = room.owner_user_id == user_id
-        is_friend = self.friend_repository.get_by_owner_and_friend(
-            db, owner_user_id=user_id, friend_user_id=room.gift_owner_user_id
-        )
-
-        if not is_owner and not is_friend:
-            raise ForbiddenException(message="Not authorized to view this room")
+        # WISHLIST_GIFT: 방장이거나 친구인지 확인
+        # PRODUCT_LADDER: 누구나 조회 가능
+        if room.room_type == "WISHLIST_GIFT":
+            is_owner = room.owner_user_id == user_id
+            is_friend = self.friend_repository.get_by_owner_and_friend(
+                db, owner_user_id=user_id, friend_user_id=room.gift_owner_user_id
+            )
+            if not is_owner and not is_friend:
+                raise ForbiddenException(message="Not authorized to view this room")
 
         # 참여자 목록
         participants = self.participant_repository.list_by_room(db, room_id, state="JOINED")
@@ -86,30 +113,40 @@ class RoomService:
             if game:
                 game_result = self.game_result_repository.get_by_game(db, game.id)
                 if game_result:
-                    # 레디한 참여자 목록
                     ready_participants = [p for p in participants if p.is_ready]
                     participant_user_ids = [p.user_id for p in ready_participants]
 
-                    # 방장(선물 받는 사람)인지 확인
-                    is_recipient = user_id == room.gift_owner_user_id
-
-                    if is_recipient:
-                        # 방장: 참여자 목록만 보임, 당첨자는 숨김
+                    if room.room_type == "WISHLIST_GIFT":
+                        # WISHLIST_GIFT: 방장은 참여자 목록만, 참여자는 당첨자만
+                        is_recipient = user_id == room.gift_owner_user_id
+                        if is_recipient:
+                            response.game_result = GameResultInfo(
+                                game_id=game_result.game_id,
+                                payer_user_id=None,
+                                recipient_user_id=game_result.recipient_user_id,
+                                product_id=game_result.product_id,
+                                participant_user_ids=participant_user_ids,
+                            )
+                        else:
+                            response.game_result = GameResultInfo(
+                                game_id=game_result.game_id,
+                                payer_user_id=game_result.payer_user_id,
+                                recipient_user_id=game_result.recipient_user_id,
+                                product_id=game_result.product_id,
+                                participant_user_ids=[],
+                            )
+                    else:
+                        # PRODUCT_LADDER: 모두에게 당첨자(recipient) 공개
+                        # payer_user_ids는 game_payers 테이블에서 조회
+                        payers = self.game_payer_repository.list_by_game_result(db, game_result.id)
+                        payer_user_ids = [p.user_id for p in payers]
                         response.game_result = GameResultInfo(
                             game_id=game_result.game_id,
                             payer_user_id=None,
                             recipient_user_id=game_result.recipient_user_id,
                             product_id=game_result.product_id,
                             participant_user_ids=participant_user_ids,
-                        )
-                    else:
-                        # 참여자: 당첨자만 보임
-                        response.game_result = GameResultInfo(
-                            game_id=game_result.game_id,
-                            payer_user_id=game_result.payer_user_id,
-                            recipient_user_id=game_result.recipient_user_id,
-                            product_id=game_result.product_id,
-                            participant_user_ids=[],
+                            payer_user_ids=payer_user_ids,
                         )
 
         return response
@@ -149,6 +186,11 @@ class RoomService:
         rooms = self.room_repository.list_by_friend(db, friend_user_id)
         return [self._to_room_response(db, room) for room in rooms]
 
+    def list_rooms_by_product(self, db: Session, product_id: int) -> List[RoomResponse]:
+        """특정 상품의 OPEN 상태 PRODUCT_LADDER 방 목록"""
+        rooms = self.room_repository.list_by_product(db, product_id)
+        return [self._to_room_response(db, room) for room in rooms]
+
     def join_room(self, db: Session, user_id: int, room_id: int) -> ParticipantResponse:
         """방 입장"""
         room = self.room_repository.get_by_id(db, room_id)
@@ -162,12 +204,14 @@ class RoomService:
         if room.owner_user_id == user_id:
             raise BadRequestException(message="Owner cannot join as participant")
 
-        # 친구인지 확인
-        is_friend = self.friend_repository.get_by_owner_and_friend(
-            db, owner_user_id=user_id, friend_user_id=room.gift_owner_user_id
-        )
-        if not is_friend:
-            raise ForbiddenException(message="Only friends can join")
+        # WISHLIST_GIFT: 친구인지 확인
+        # PRODUCT_LADDER: 누구나 입장 가능
+        if room.room_type == "WISHLIST_GIFT":
+            is_friend = self.friend_repository.get_by_owner_and_friend(
+                db, owner_user_id=user_id, friend_user_id=room.gift_owner_user_id
+            )
+            if not is_friend:
+                raise ForbiddenException(message="Only friends can join")
 
         # 이미 참여했는지 확인
         existing = self.participant_repository.get_by_room_and_user(db, room_id, user_id)
@@ -216,20 +260,32 @@ class RoomService:
         participants = self.participant_repository.list_by_room(db, room.id, state="JOINED")
         ready_participants = [p for p in participants if p.is_ready]
 
-        # 랜덤으로 당첨자(payer) 선정
-        payer = random.choice(ready_participants)
-
         # Game 생성
         game = self.game_repository.create(db, room_id=room.id)
 
-        # GameResult 생성
-        game_result = self.game_result_repository.create(
-            db,
-            game_id=game.id,
-            product_id=room.product_id,
-            recipient_user_id=room.gift_owner_user_id,  # 선물 받는 사람 = 방장
-            payer_user_id=payer.user_id,  # 당첨자 = 선물 사는 사람
-        )
+        if room.room_type == "WISHLIST_GIFT":
+            # WISHLIST_GIFT: 랜덤으로 당첨자(payer) 선정, recipient는 방장
+            payer = random.choice(ready_participants)
+            game_result = self.game_result_repository.create(
+                db,
+                game_id=game.id,
+                product_id=room.product_id,
+                recipient_user_id=room.gift_owner_user_id,
+                payer_user_id=payer.user_id,
+            )
+        else:
+            # PRODUCT_LADDER: 랜덤으로 당첨자(recipient) 선정, 나머지는 payer
+            winner = random.choice(ready_participants)
+            game_result = self.game_result_repository.create(
+                db,
+                game_id=game.id,
+                product_id=room.product_id,
+                recipient_user_id=winner.user_id,
+                payer_user_id=None,
+            )
+            # 당첨자 제외 나머지를 payer로 등록
+            loser_user_ids = [p.user_id for p in ready_participants if p.user_id != winner.user_id]
+            self.game_payer_repository.create_bulk(db, game_result.id, loser_user_ids)
 
         # 방 상태 변경
         self.room_repository.update_status(db, room, "DONE")


### PR DESCRIPTION
## Summary
- PRODUCT_LADDER 방 타입 추가 (상품 기반 사다리타기)
- GamePayer 모델로 다중 결제자 지원
- 상품별 방 생성/조회 API 추가

## 변경 사항
- `GamePayer` 모델 추가 (다중 결제자 테이블)
- `POST /api/v1/products/{product_id}/rooms` - 상품 방 생성
- `GET /api/v1/products/{product_id}/rooms` - 상품별 방 목록 조회
- 방 입장/조회 시 방 타입별 권한 분기 처리
  - WISHLIST_GIFT: 친구만 입장 가능
  - PRODUCT_LADDER: 누구나 입장 가능
- 사다리타기 결과 로직 방 타입별 분기
  - WISHLIST_GIFT: 랜덤 당첨자 = 결제자, 방장 = 수령자
  - PRODUCT_LADDER: 랜덤 당첨자 = 수령자, 나머지 = 결제자들

## Test plan
- [ ] 상품 방 생성 테스트
- [ ] 상품별 방 목록 조회 테스트
- [ ] PRODUCT_LADDER 방 입장 테스트 (친구 아닌 유저)
- [ ] PRODUCT_LADDER 사다리타기 결과 확인